### PR TITLE
Fix: Correct action block to use cycle_complete_actions input

### DIFF
--- a/blueprints/dishwasher-alert.yaml
+++ b/blueprints/dishwasher-alert.yaml
@@ -35,6 +35,4 @@ trigger:
   from: Drying
   to: N/A
 action:
-- choose:
-  - conditions: '{{ post_charge_actions is defined }}'
-    sequence: !input cycle_complete_actions
+  - sequence: !input cycle_complete_actions


### PR DESCRIPTION
## Fix: Correct action block to use cycle_complete_actions input

### Description

This PR updates the `blueprints/dishwasher-alert.yaml` blueprint to fix an issue with the action block.  
Previously, the action referenced an undefined variable (`post_charge_actions`), which prevented the `cycle_complete_actions` from running as intended.

**Changes:**
- Replaces the incorrect conditional block with a direct call to `!input cycle_complete_actions`.
- Ensures that the actions specified by the user will trigger when the dishwasher cycle is complete.

### Motivation and Context

- Ensures that the blueprint works as expected and triggers the specified actions when the dishwasher finishes its cycle.
- Fixes a bug that caused the automation to never execute the user-defined actions.

### How Has This Been Tested?

- Reviewed the YAML for correctness and verified that the action block now references the correct input.
- (If applicable) Tested in Home Assistant to confirm the automation triggers as expected.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have tested the changes in a Home Assistant environment

---